### PR TITLE
More generic flash_xc3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Building
 
-Needs migen and ISE.
+Needs [migen](https://github.com/m-labs/migen) and [Xilinx ISE](https://www.xilinx.com/products/design-tools/ise-design-suite.html).
 
 ```
 make

--- a/README.md
+++ b/README.md
@@ -8,17 +8,31 @@
 
 ## Building
 
-Needs [migen](https://github.com/m-labs/migen) and [Xilinx ISE](https://www.xilinx.com/products/design-tools/ise-design-suite.html).
+Needs [migen](https://github.com/m-labs/migen) and [Xilinx ISE](https://www.xilinx.com/products/design-tools/ise-design-suite.html). Assumes ISE is installed in ``/opt/Xilinx``.
 
 ```
 make
-# and then look at/use flash.sh or make flash
-
-# or use fxload and xc3sprog:
-/sbin/fxload -t fx2 -I /opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/xusb_xp2.hex -D /dev/bus/usb/001/*`cat /sys/bus/usb/devices/1-3/devnum` && sleep 10 && \
-xc3sprog -c xpc -m /opt/Xilinx/14.7/ISE_DS/ISE/xbr/data -v build/mirny.jed:w
-# look for "Verify: Success"
 ```
+
+## Flashing
+
+With Digilent [JTAG HS2](https://store.digilentinc.com/jtag-hs2-programming-cable/) cable:
+
+  - download firmware to dongle. Manually (adjust USB bus as needed):
+  ```
+  /sbin/fxload -t fx2 -I /opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/xusb_xp2.hex -D /dev/bus/usb/001/*`cat /sys/bus/usb/devices/1-3/devnum`
+  ```
+  or automatically via the ``udev`` rule:
+  ```
+  SUBSYSTEM=="usb", ACTION="add", ATTR{idVendor}=="0403", ATTR{idProduct}=="6014", ATTR{manufacturer}=="Digilent", RUN+="/usr/bin/fxload -v -t fx2 -I /opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/xusb_xp2.hex -D $tempnode"
+  ```
+
+  - install [xc3sprog](http://xc3sprog.sourceforge.net/)
+
+  - ``flash_xc3.sh jtaghs2``
+
+  - look for ``Verify: Success``
+
 
 # License
 

--- a/flash_xc3.sh
+++ b/flash_xc3.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 set -e
-set -x
 
-/sbin/fxload -t fx2 -I /opt/Xilinx/14.7/ISE_DS/ISE/bin/lin64/xusb_xp2.hex -D /dev/bus/usb/001/*`cat /sys/bus/usb/devices/1-7/devnum`
-sleep 7
-../xc3sprog/build/xc3sprog -c xpc -m /opt/Xilinx/14.7/ISE_DS/ISE/xbr/data -v build/mirny.jed:w
+XC3SPROG=xc3sprog
+CABLE=$([[ -z "$1" ]] && echo "xpc" || echo "$1")
+
+set -x
+$XC3SPROG -c $CABLE -m /opt/Xilinx/14.7/ISE_DS/ISE/xbr/data -v build/mirny.jed:w

--- a/flash_xc3.sh
+++ b/flash_xc3.sh
@@ -3,7 +3,7 @@
 set -e
 
 XC3SPROG=xc3sprog
-CABLE=$([[ -z "$1" ]] && echo "xpc" || echo "$1")
+CABLE=${1-xpc}
 
 set -x
 $XC3SPROG -c $CABLE -m /opt/Xilinx/14.7/ISE_DS/ISE/xbr/data -v build/mirny.jed:w


### PR DESCRIPTION
Adds more details for flashing with ``xc3sprog``. Supports other cable types.
Setting the usb bus the ``fxload`` call manually is not robust. A ``udev`` rule fixes this at the expense of extra configuration.
USB vid:pid ``0403:6014`` is "FTDI:FT232H Single HS USB-UART/FIFO IC" so the manufacturer check is necessary.
Tested with Digilent JTAG HS2 dongle.